### PR TITLE
fix: respect `config.useEnglish` in settings activity

### DIFF
--- a/app/src/main/kotlin/org/fossify/thankyou/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/thankyou/activities/SettingsActivity.kt
@@ -3,12 +3,12 @@ package org.fossify.thankyou.activities
 import android.annotation.SuppressLint
 import android.content.ContentValues
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.fossify.commons.activities.BaseComposeActivity
 import org.fossify.commons.compose.extensions.enableEdgeToEdgeSimple
 import org.fossify.commons.compose.theme.AppThemeSurface
 import org.fossify.commons.extensions.updateGlobalConfig
@@ -21,7 +21,7 @@ import org.fossify.thankyou.ui.screens.SettingsScreen
 import java.util.Locale
 import kotlin.system.exitProcess
 
-class SettingsActivity : ComponentActivity() {
+class SettingsActivity : BaseComposeActivity() {
 
     private val preferences by lazy { config }
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Inherit `BaseComposeActivity`

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Thank-You/issues/75

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
