### PR TITLE
fix: replace `Use English language` checkbox with switch

### DIFF
--- a/app/src/main/kotlin/org/fossify/thankyou/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/fossify/thankyou/ui/screens/SettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.res.stringResource
 import org.fossify.commons.R
 import org.fossify.commons.compose.extensions.MyDevices
 import org.fossify.commons.compose.lists.SimpleColumnScaffold
-import org.fossify.commons.compose.settings.SettingsCheckBoxComponent
 import org.fossify.commons.compose.settings.SettingsGroup
 import org.fossify.commons.compose.settings.SettingsHorizontalDivider
 import org.fossify.commons.compose.settings.SettingsPreferenceComponent
@@ -43,10 +42,11 @@ internal fun SettingsScreen(
                 SettingsTitleTextComponent(text = stringResource(id = R.string.general_settings))
             }) {
                 if (isUseEnglishEnabled) {
-                    SettingsCheckBoxComponent(
+                    SettingsSwitchComponent(
                         label = stringResource(id = R.string.use_english_language),
                         initialValue = isUseEnglishChecked,
                         onChange = onUseEnglishPress,
+                        showCheckmark = isShowingCheckmarksOnSwitches
                     )
                 }
                 if (isTiramisuPlus()) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Replaced `SettingsCheckBoxComponent` with `SettingsSwitchComponent`

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- See https://github.com/orgs/FossifyOrg/discussions/78 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
